### PR TITLE
Support for denoting dirty trees

### DIFF
--- a/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
@@ -36,10 +36,10 @@ class GitInfoService implements SCMInfoService {
     }
 
     static boolean isGitTreeDirty(File dir) {
-        return run(dir, 'git', 'status', '--porcelain').trim() != ''
-//        return 'git update-index -q --ignore-submodules --refresh'.execute([], dir).waitFor() ||
-//                'git diff-files --quiet --ignore-submodules --'.execute([], dir).waitFor() ||
-//                'git diff-index --cached --quiet HEAD --ignore-submodules --'.execute([], dir).waitFor()
+//        return run(dir, 'git', 'status', '--porcelain').trim() != ''
+        return 'git update-index -q --ignore-submodules --refresh'.execute([], dir).waitFor() ||
+                'git diff-files --quiet --ignore-submodules --'.execute([], dir).waitFor() ||
+                'git diff-index --cached --quiet HEAD --ignore-submodules --'.execute([], dir).waitFor()
     }
 
     @Override

--- a/src/test/groovy/net/nemerosa/versioning/git/GitInfoServiceTest.groovy
+++ b/src/test/groovy/net/nemerosa/versioning/git/GitInfoServiceTest.groovy
@@ -26,8 +26,9 @@ class GitInfoServiceTest {
             repo.with {
                 git 'init'
                 commit 1
-                // Add a file
-                cmd 'touch', 'test.txt'
+                // Need to modify a tracked file, not just create a new untracked file
+                //cmd 'touch', 'test.txt'
+				new File(dir, 'file1') << 'Add some content'
             }
             assert GitInfoService.isGitTreeDirty(repo.dir): "Unstaged changes"
         } finally {

--- a/src/test/groovy/net/nemerosa/versioning/git/GitVersionTest.groovy
+++ b/src/test/groovy/net/nemerosa/versioning/git/GitVersionTest.groovy
@@ -613,8 +613,9 @@ VERSION_SCM = git
                 git 'tag', '2.0.2'
                 commit 6
                 git 'log', '--oneline', '--graph', '--decorate', '--all'
-                // Add a file
-                cmd 'touch', 'test.txt'
+                // Nope, got to mod an existing file 
+                //cmd 'touch', 'test.txt'
+		new File(dir, 'file5') << 'Add some content'
             }
             def head = repo.commitLookup('Commit 6')
             def headAbbreviated = repo.commitLookup('Commit 6', true)

--- a/src/test/groovy/net/nemerosa/versioning/git/GitVersionTest.groovy
+++ b/src/test/groovy/net/nemerosa/versioning/git/GitVersionTest.groovy
@@ -497,8 +497,9 @@ VERSION_SCM = git
                 git 'checkout', '-b', 'feature/123-great'
                 commit 5
                 git 'log', '--oneline', '--graph', '--decorate', '--all'
-                // Add a file
-                cmd 'touch', 'test.txt'
+                // Nope, got to mod an existing tracked file
+                //cmd 'touch', 'test.txt'
+				new File(dir, 'file5') << 'Add some content'
             }
             def head = repo.commitLookup('Commit 5')
             def headAbbreviated = repo.commitLookup('Commit 5', true)
@@ -570,8 +571,9 @@ VERSION_SCM = git
                 git 'checkout', '-b', 'feature/123-great'
                 commit 5
                 git 'log', '--oneline', '--graph', '--decorate', '--all'
-                // Add a file
-                cmd 'touch', 'test.txt'
+                // Nope, need to mod an existing file to make the tree dirty
+                //cmd 'touch', 'test.txt'
+				new File(dir, 'file5') << 'Add some content'
             }
             def head = repo.commitLookup('Commit 5')
             def headAbbreviated = repo.commitLookup('Commit 5', true)
@@ -649,8 +651,9 @@ VERSION_SCM = git
                 git 'tag', '2.0.2'
                 commit 6
                 git 'log', '--oneline', '--graph', '--decorate', '--all'
-                // Add a file
-                cmd 'touch', 'test.txt'
+                // Nope, got to mod an existing file
+                //cmd 'touch', 'test.txt'
+				new File(dir, 'file5') << 'Mod the content'
             }
             def head = repo.commitLookup('Commit 6')
             def headAbbreviated = repo.commitLookup('Commit 6', true)
@@ -690,8 +693,9 @@ VERSION_SCM = git
                 git 'tag', '2.0.2'
                 commit 6
                 git 'log', '--oneline', '--graph', '--decorate', '--all'
-                // Add a file
-                cmd 'touch', 'test.txt'
+                // Nope, got to mod an existing file
+                //cmd 'touch', 'test.txt'
+				new File(dir, 'file5') << 'Mod the content'
             }
             def head = repo.commitLookup('Commit 6')
             def headAbbreviated = repo.commitLookup('Commit 6', true)
@@ -731,8 +735,9 @@ VERSION_SCM = git
                 git 'tag', '2.0.2'
                 commit 6
                 git 'log', '--oneline', '--graph', '--decorate', '--all'
-                // Add a file
-                cmd 'touch', 'test.txt'
+                // Nope, mod an existing file
+                //cmd 'touch', 'test.txt'
+				new File(dir, 'file5') << 'mod the content'
             }
             def head = repo.commitLookup('Commit 6')
             def headAbbreviated = repo.commitLookup('Commit 6', true)


### PR DESCRIPTION
As discussed in issue #15.

The difference here is that I modified the unit tests that were failing so they now all pass.  A dirty tree is a tree that has staged files that are uncommitted or has changes to *tracked* files that have not been staged.  Checking out a tree and creating a new *untracked* file is not a dirty tree.  Your unit tests were assuming that creating a new file in a tree makes it dirty, that is not the case.