### PR TITLE
get branch from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ versioning {
         }
     }
     /**
+     * Fetch branch name from environment variables. Useful when using CI like
+     * Travis or Jenkins.
+     */
+    branchEnv = ['TRAVIS_BRANCH', 'GIT_BRANCH', 'SVN_BRANCH', 'BRANCH_NAME']
+    /**
      * Computation of the full version
      */
     full = { branchId, abbreviated -> "${branchId}-${abbreviated}" }

--- a/build.gradle
+++ b/build.gradle
@@ -71,3 +71,8 @@ bintray {
 task wrapper(type: Wrapper) {
    gradleVersion = '2.13'
 }
+
+test {
+  environment "GIT_TEST_BRANCH", "feature/456-cute"
+  environment "SVN_TEST_BRANCH", "feature-456-cute"
+}

--- a/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
@@ -49,6 +49,11 @@ class VersioningExtension {
     String scm = 'git'
 
     /**
+     * Fetch the branch from env Variable
+     */
+    List branchEnv = ['TRAVIS_BRANCH', 'GIT_BRANCH', 'SVN_BRANCH', 'BRANCH_NAME']
+
+    /**
      * Getting the version type from a branch. Default: getting the part before the first "/" (or a second
      * optional 'separator' parameter). If no slash is found, takes the branch name as whole.
      *

--- a/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
@@ -24,8 +24,20 @@ class GitInfoService implements SCMInfoService {
             // Open the Git repo
             //noinspection GroovyAssignabilityCheck
             def grgit = Grgit.open(currentDir: project.projectDir)
-            // Gets the branch info
-            String branch = grgit.branch.current.name
+
+            // Check passed in environment variable list
+            String branch = null
+            for (ev in extension.branchEnv) {
+                if (System.env[ev] != null) {
+                    branch = System.env[ev]
+                    break
+                }
+            }
+            // Gets the branch info from git
+            if (branch == null) {
+                branch = grgit.branch.current.name
+            }
+
             // Gets the commit info (full hash)
             List<Commit> commits = grgit.log(maxCommits: 1)
             if (commits.empty) {

--- a/src/main/groovy/net/nemerosa/versioning/svn/SVNInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/svn/SVNInfoService.groovy
@@ -29,10 +29,21 @@ class SVNInfoService implements SCMInfoService {
                     project.projectDir,
                     SVNRevision.HEAD
             )
-            // URL
-            String url = info.URL as String
-            // Branch parsing
-            String branch = parseBranch(url)
+
+            // Check passed in environment variable list
+            String branch = null
+            for (ev in extension.branchEnv) {
+                if (System.env[ev] != null) {
+                    branch = System.env[ev]
+                    break
+                }
+            }
+            // Branch parsing from URL
+            if (branch == null) {
+                String url = info.URL as String
+                branch = parseBranch(url)
+            }
+
             // Revision
             String revision = info.committedRevision.number as String
             // OK

--- a/src/test/groovy/net/nemerosa/versioning/svn/SVNVersionTest.groovy
+++ b/src/test/groovy/net/nemerosa/versioning/svn/SVNVersionTest.groovy
@@ -704,4 +704,33 @@ VERSION_SCM=svn
         project.versioning.info as VersionInfo
     }
 
+    @Test
+    void 'SVN branch with env TEST_BRANCH'() {
+
+        // SVN
+        repo.mkdir 'project/branches/feature-test-1-my-feature', 'Feature branch'
+        repo.mkdir 'project/branches/feature-test-1-my-feature/1', 'Commit for TEST-1'
+        repo.mkdir 'project/branches/feature-test-1-my-feature/2', 'Commit for TEST-1'
+
+        // Project
+        def project = ProjectBuilder.builder().withProjectDir(repo.checkout('project/branches/feature-test-1-my-feature')).build()
+        new VersioningPlugin().apply(project)
+        project.versioning {
+            scm = 'svn'
+            branchEnv << 'SVN_TEST_BRANCH'
+        }
+
+        // Gets the info and checks it
+        VersionInfo info = project.versioning.info as VersionInfo
+        assert info != null
+        assert info.build == '3'
+        assert info.branch == 'feature-456-cute'
+        assert info.base == '456-cute'
+        assert info.branchId == 'feature-456-cute'
+        assert info.branchType == 'feature'
+        assert info.commit == '3'
+        assert info.display == "feature-456-cute-3"
+        assert info.full == "feature-456-cute-3"
+        assert info.scm == 'svn'
+    }
 }


### PR DESCRIPTION
Let user to specify branch name into custom environment variables.
It is useful when using CI tools like Travis or Jenkins, and code is cloned in a detached way.