### PR TITLE
Generalize release parsing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,19 +183,14 @@ versioning {
     */
    scm = 'git'
    /**
-    * Computation of the branch type and the base, by parsing the branch name.
-    * By default, we use "/" as a separator between the type and the base. If not
+    * Computation of the release type and the base, by parsing the scm info.
+    * By default, we use "/" as a separator in branch name between the type and the base. If not
     * present, the type is the branch and the base is empty.
+    * F.e. if you want use tag name instead of branch you may provide something like:
     */
-    branchParser = { String branch, String separator = '/' ->
-        int pos = branch.indexOf(separator)
-        if (pos > 0) {
-            new BranchInfo(
-               type: branch.substring(0, pos),
-               base: branch.substring(pos + 1))
-        } else {
-            new BranchInfo(type: branch, base: '')
-        }
+    releaseParser = { scmInfo, separator = '/' -> ->
+        List<String> part = scmInfo.tag.split('/') + ''
+        new net.nemerosa.versioning.ReleaseInfo(type: part[0], base: part[1])
     }
     /**
      * Fetch branch name from environment variables. Useful when using CI like
@@ -205,7 +200,7 @@ versioning {
     /**
      * Computation of the full version
      */
-    full = { branchId, abbreviated -> "${branchId}-${abbreviated}" }
+    full = { scmInfo -> "${scmInfo.branch}-${scmInfo.abbreviated}" }
     /**
      * Set of eligible branch types for computing a display version from the branch base name
      */

--- a/src/main/groovy/net/nemerosa/versioning/ReleaseInfo.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/ReleaseInfo.groovy
@@ -3,7 +3,7 @@ package net.nemerosa.versioning
 import groovy.transform.Canonical
 
 @Canonical
-class BranchInfo {
+class ReleaseInfo {
 
     String type
     String base


### PR DESCRIPTION
By discussion in https://github.com/nemerosa/versioning/issues/32

* Class `BranchInfo` renamed to `ReleaseInfo`
* `branchParser` closure refactored into `releaseParser` and take now instance of `SCMInfo` class instead of separate parameters like branch name.
* Same changes for `full` configuration closure
* Test `net.nemerosa.versioning.git.GitVersionTest` extended by method `Git release by tag: custom release logic` to demonstrate logic