### PR TITLE
#37 PR for issue 37 - has git check to check project directory and custom location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,12 @@ dependencies {
     compile "org.eclipse.jgit:org.eclipse.jgit.ui:${jgitVersion}"
     compile "org.eclipse.jgit:org.eclipse.jgit:${jgitVersion}"
     compile 'org.tmatesoft.svnkit:svnkit:1.8.12'
+    testCompile "junit:junit:4.12"
+    testCompile "commons-lang:commons-lang:2.6"
+    testCompile "commons-io:commons-io:2.5"
+
+
+
 }
 
 /**

--- a/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
@@ -49,12 +49,12 @@ class VersioningExtension {
     String scm = 'git'
 
     /**
-     * Allow setting location of .git file for non conventional git/gradle setups.
-     * This is the path to the .git folder used to validate if git is present for the current
-     * project.
+     * Allow setting the root git repo directory for non conventional git/gradle setups.
+     * This is the path to the root directory that contains the .git folder. This
+     * is used to validate if the current project is a git repository.
      *
      */
-    String dotgitPath = null
+    String gitRepoRootDir = null
 
     /**
      * Fetch the branch from environment variable if available.

--- a/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
@@ -49,6 +49,14 @@ class VersioningExtension {
     String scm = 'git'
 
     /**
+     * Allow setting location of .git file for non conventional git/gradle setups.
+     * This is the path to the .git folder used to validate if git is present for the current
+     * project.
+     *
+     */
+    String dotgitPath = null
+
+    /**
      * Fetch the branch from environment variable if available.
      *
      * By default, the environment is not taken into account, in order to be backward compatible

--- a/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
@@ -21,7 +21,8 @@ class GitInfoService implements SCMInfoService {
         // Is Git enabled?
         boolean hasGit = project.rootProject.file('.git').exists() ||
                          project.file('.git').exists() ||
-                         (extension.dotgitPath != null && new File(extension.dotgitPath).exists())
+                         (extension.gitRepoRootDir != null &&
+                                 new File("${extension.gitRepoRootDir}${File.pathSeparator}.git").exists())
         // No Git information
         if (!hasGit) {
             SCMInfo.NONE

--- a/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
@@ -19,7 +19,9 @@ class GitInfoService implements SCMInfoService {
     @Override
     SCMInfo getInfo(Project project, VersioningExtension extension) {
         // Is Git enabled?
-        boolean hasGit = project.rootProject.file('.git').exists()
+        boolean hasGit = project.rootProject.file('.git').exists() ||
+                         project.file('.git').exists() ||
+                         (extension.dotgitPath != null && new File(extension.dotgitPath).exists())
         // No Git information
         if (!hasGit) {
             SCMInfo.NONE


### PR DESCRIPTION
We have a slightly unconventional layout for some of our projects that means the .git folder may not be in the project.rootProject.file('.git') location. Also the code in GitInfoService uses the project path and not the root .git location
def grgit = Grgit.open(currentDir: project.projectDir)

Also in one case we have a git repo where the java project is not at the root directory so we need a way to specify the location of the .git location.