### PR TITLE
Use Logger for output

### DIFF
--- a/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
@@ -232,7 +232,7 @@ class VersioningExtension {
                 throw new DirtyException()
             } else {
                 if (!noWarningOnDirty) {
-                    println "[versioning] WARNING - the working copy has unstaged or uncommitted changes."
+                    project.getLogger().warn("[versioning] WARNING - the working copy has unstaged or uncommitted changes.")
                 }
                 versionDisplay = dirty(versionDisplay)
                 versionFull = dirty(versionFull)

--- a/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/VersioningExtension.groovy
@@ -35,7 +35,7 @@ class VersioningExtension {
      * Registry of release modes
      */
     private static final Map<String, Closure<String>> RELEASE_MODES = [
-            tag : { nextTag, lastTag, currentTag, extension ->
+            tag     : { nextTag, lastTag, currentTag, extension ->
                 nextTag
             },
             snapshot: { nextTag, lastTag, currentTag, extension ->
@@ -62,7 +62,7 @@ class VersioningExtension {
      * By default, the environment is not taken into account, in order to be backward compatible
      * with existing build systems.
      */
-    List branchEnv = []
+    List<String> branchEnv = []
 
     /**
      * Getting the version type from a branch. Default: getting the part before the first "/" (or a second
@@ -100,7 +100,7 @@ class VersioningExtension {
     def releaseMode = 'tag'
 
     /**
-     * True if it's release build. Default is true, and branch shoud be in releases-set.
+     * True if it's release build. Default is true, and branch should be in releases-set.
      */
     def releaseBuild = true
 
@@ -131,7 +131,7 @@ class VersioningExtension {
     /**
      * If set to <code>true</code>, no warning will be printed in case the workspace is dirty.
      */
-    boolean noWarningOnDirty = false;
+    boolean noWarningOnDirty = false
 
     /**
      * Credentials (for SVN only)
@@ -296,8 +296,8 @@ class VersioningExtension {
         }
     }
 
-    public static String normalise(String value) {
-        value.replaceAll(/[^A-Za-z0-9\.\-_]/, '-')
+    static String normalise(String value) {
+        value.replaceAll(/[^A-Za-z0-9.\-_]/, '-')
     }
 
     private static SCMInfoService getSCMInfoService(String type) {

--- a/src/main/groovy/net/nemerosa/versioning/svn/SVNInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/svn/SVNInfoService.groovy
@@ -175,12 +175,12 @@ class SVNInfoService implements SCMInfoService {
         def clientManager = SVNClientManager.newInstance()
         if (extension.user && extension.password) {
             LOGGER.info("[version] Authenticating with ${extension.user}")
-            clientManager.setAuthenticationManager(BasicAuthenticationManager.newInstance(extension.user, extension.password.toCharArray()));
+            clientManager.setAuthenticationManager(BasicAuthenticationManager.newInstance(extension.user, extension.password.toCharArray()))
             // The BasicAuthenticationManager trusts the certificates by default
         } else if (extension.trustServerCert) {
             LOGGER.info("[version] Trusting certificate by default")
             LOGGER.warn("[version] WARNING The `trustServerCert` is now deprecated - and should not be used any longer.")
-            clientManager.setAuthenticationManager(BasicAuthenticationManager.newInstance(new SVNAuthentication[0]));
+            clientManager.setAuthenticationManager(BasicAuthenticationManager.newInstance(new SVNAuthentication[0]))
         } else {
             LOGGER.info("[version] Using default SVN configuration")
             clientManager.setAuthenticationManager(SVNWCUtil.createDefaultAuthenticationManager())

--- a/src/main/groovy/net/nemerosa/versioning/svn/SVNInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/svn/SVNInfoService.groovy
@@ -4,6 +4,8 @@ import net.nemerosa.versioning.SCMInfo
 import net.nemerosa.versioning.SCMInfoService
 import net.nemerosa.versioning.VersioningExtension
 import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
 import org.tmatesoft.svn.core.SVNDepth
 import org.tmatesoft.svn.core.SVNDirEntry
 import org.tmatesoft.svn.core.SVNException
@@ -13,6 +15,8 @@ import org.tmatesoft.svn.core.auth.SVNAuthentication
 import org.tmatesoft.svn.core.wc.*
 
 class SVNInfoService implements SCMInfoService {
+
+    private static final Logger LOGGER = Logging.getLogger(this.getClass())
 
     @Override
     SCMInfo getInfo(Project project, VersioningExtension extension) {
@@ -120,7 +124,7 @@ class SVNInfoService implements SCMInfoService {
         }
         // Gets the list of tags
         String tagsUrl = "${baseUrl}/tags"
-        println "[version] Getting list of tags from ${tagsUrl}..."
+        LOGGER.info("[version] Getting list of tags from ${tagsUrl}...")
         // Gets the list
         List<SVNDirEntry> entries = []
         try {
@@ -170,15 +174,15 @@ class SVNInfoService implements SCMInfoService {
     protected static SVNClientManager getClientManager(VersioningExtension extension) {
         def clientManager = SVNClientManager.newInstance()
         if (extension.user && extension.password) {
-            println "[version] Authenticating with ${extension.user}"
+            LOGGER.info("[version] Authenticating with ${extension.user}")
             clientManager.setAuthenticationManager(BasicAuthenticationManager.newInstance(extension.user, extension.password.toCharArray()));
             // The BasicAuthenticationManager trusts the certificates by default
         } else if (extension.trustServerCert) {
-            println "[version] Trusting certificate by default"
-            println "[version] WARNING The `trustServerCert` is now deprecated - and should not be used any longer."
+            LOGGER.info("[version] Trusting certificate by default")
+            LOGGER.warn("[version] WARNING The `trustServerCert` is now deprecated - and should not be used any longer.")
             clientManager.setAuthenticationManager(BasicAuthenticationManager.newInstance(new SVNAuthentication[0]));
         } else {
-            println "[version] Using default SVN configuration"
+            LOGGER.info("[version] Using default SVN configuration")
             clientManager.setAuthenticationManager(SVNWCUtil.createDefaultAuthenticationManager())
         }
         return clientManager


### PR DESCRIPTION
Hi,

I've put together a pull request for switching the plugin output to use a `Logger` rather than `println` directly because it gives users of the plugin more control over how much output they see.

The only output I haven't touched is that from `VersionDisplayTask` because the point of the task is to output to `stdout`.  As it turns out, that actually means I've only changed two classes: the dirty warning in `VersioningExtension` and various places in `SVNInfoService`; the Subversion side of the plugin seems to be much more vocal than the Git side.

Personally, I prefer my builds to be mute as far as possible unless something fails, because I find this helps prevent the important output being lost in a sea of text.  Other people prefer a more verbose build.  The `Logger` gives us the best of both worlds.

Lastly, I've included a second commit with the non-functional code cleanup my IDE suggested in the files I modified.  I don't know what your preferences are on that front, so I wanted to make it easy to exclude those changes if you want to.