### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ before_install:
   - git config --global user.name "Travis CI"
 
 script:
-  - ./gradlew clean versionDisplay build --stacktrace
+  - ./gradlew clean versionDisplay build --stacktrace --scan

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@
 
 plugins {
     /**
+     * Build performance
+     */
+    id 'com.gradle.build-scan' version '1.16'
+    /**
      * Plugin
      */
     id 'java-gradle-plugin'
@@ -16,10 +20,6 @@ plugins {
      * Written in Groovy
      */
     id 'groovy'
-    /**
-     * Build performance
-     */
-    id 'com.gradle.build-scan' version '1.16'
 }
 
 buildScan {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,15 @@ plugins {
      * Written in Groovy
      */
     id 'groovy'
+    /**
+     * Build performance
+     */
+    id 'com.gradle.build-scan' version '1.16'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 /**


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.