### PR TITLE
consider tags as branches in SVN to avoid crashing while working on a tag

### DIFF
--- a/src/main/groovy/net/nemerosa/versioning/svn/SVNInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/svn/SVNInfoService.groovy
@@ -95,7 +95,7 @@ class SVNInfoService implements SCMInfoService {
         if (url ==~ /.*\/trunk$/) {
             'trunk'
         } else {
-            def m = url =~ /.*\/branches\/([^\/]+)$/
+            def m = url =~ /.*\/(?:branches|tags)\/([^\/]+)$/
             if (m.matches()) {
                 m.group(1)
             } else {

--- a/src/test/groovy/net/nemerosa/versioning/svn/SVNURLParsingTest.groovy
+++ b/src/test/groovy/net/nemerosa/versioning/svn/SVNURLParsingTest.groovy
@@ -24,9 +24,9 @@ class SVNURLParsingTest {
         SVNInfoService.parseBranch('svn://localhost/project/branches/xxx-yyy/zzz')
     }
 
-    @Test(expected = SVNInfoURLException)
+    @Test
     void 'Tag'() {
-        SVNInfoService.parseBranch('svn://localhost/project/tags/1.0')
+        assert SVNInfoService.parseBranch('svn://localhost/project/tags/1.0') == '1.0'
     }
 
     @Test(expected = SVNInfoURLException)


### PR DESCRIPTION
It is common to checkout a tag in a build pipeline to build stable versions to deliver on production.
This quick fix avoid the plugin crashing while working on a SVN tag.