### PR TITLE
upgraded to the latest GrGit and JGit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ version = versioning.info.display
  */
 
 ext {
-    jgitVersion = '5.1.1.201809181055-r'
+    jgitVersion = '5.6.0.201912101111-r'
 }
 
 repositories {
@@ -49,7 +49,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'org.ajoberstar.grgit:grgit-core:3.0.0-rc.2'
+    compile 'org.ajoberstar.grgit:grgit-core:4.0.0'
     compile "org.eclipse.jgit:org.eclipse.jgit.ui:${jgitVersion}"
     compile "org.eclipse.jgit:org.eclipse.jgit:${jgitVersion}"
     compile 'org.tmatesoft.svnkit:svnkit:1.8.12'

--- a/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
@@ -46,7 +46,7 @@ class GitInfoService implements SCMInfoService {
             }
             // Gets the branch info from git
             if (branch == null) {
-                branch = grgit.branch.current.name
+                branch = grgit.branch.current().name
             }
 
             // Gets the commit info (full hash)
@@ -72,8 +72,8 @@ class GitInfoService implements SCMInfoService {
 
                 def gitRepository = grgit.repository.jgit.repository
 
-                for (Ref r : gitRepository.refDatabase.getRefs(R_TAGS).values()) {
-                    ObjectId key = gitRepository.peel(r).getPeeledObjectId();
+                for (Ref r : gitRepository.refDatabase.getRefsByPrefix(R_TAGS)) {
+                    ObjectId key = gitRepository.refDatabase.peel(r).getPeeledObjectId();
                     if (key == null)
                         key = r.getObjectId();
                     tags.put(key, r);
@@ -169,7 +169,7 @@ class GitInfoService implements SCMInfoService {
         // ... filters using the pattern
                 .findAll { (it.name =~ tagPattern).find() }
         // ... sort by desc commit time
-                .sort { -it.commit.time }
+                .sort { -it.commit.dateTime.toEpochSecond() }
         // ... (#36) commit time is not enough. We have also to consider the case where several pattern compliant tags
         // ...       are on the same commit, and we must sort them by desc version
                 .sort { -TagSupport.tagOrder(tagPattern, it.name) }


### PR DESCRIPTION
sadly, the API for JGit is envolving without much backward compatibility. this plugin currently breaks the build if some other plugin with a newer version of JGit is applied.