### PR TITLE
Fixes #72 incorrect lastTag calculation

### DIFF
--- a/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
+++ b/src/main/groovy/net/nemerosa/versioning/git/GitInfoService.groovy
@@ -168,13 +168,14 @@ class GitInfoService implements SCMInfoService {
         return grgit.tag.list()
         // ... filters using the pattern
                 .findAll { (it.name =~ tagPattern).find() }
+                .sort{ a,b ->
         // ... sort by desc commit time
-                .sort { -it.commit.time }
+                    b.commit.time <=> a.commit.time ?:
         // ... (#36) commit time is not enough. We have also to consider the case where several pattern compliant tags
         // ...       are on the same commit, and we must sort them by desc version
-                .sort { -TagSupport.tagOrder(tagPattern, it.name) }
+                    TagSupport.tagOrder(tagPattern, b.name) <=> TagSupport.tagOrder(tagPattern, a.name)
         // ... gets their name only
-                .collect { it.name }
+                }*.name
     }
 
     @Override


### PR DESCRIPTION
sorting strategy described below:
- first we sort by commit time (desc)
- then we sort on the tag (last digits, desc)