### PR TITLE
Bump grgit-core from 4.0.0 to 4.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'org.ajoberstar.grgit:grgit-core:4.0.0'
+    compile 'org.ajoberstar.grgit:grgit-core:4.0.1'
     compile "org.eclipse.jgit:org.eclipse.jgit.ui:${jgitVersion}"
     compile "org.eclipse.jgit:org.eclipse.jgit:${jgitVersion}"
     compile 'org.tmatesoft.svnkit:svnkit:1.8.12'


### PR DESCRIPTION
  * Fix Missing implementation of resolved method 'abstract org.eclipse.jgit.storage.file.FileBasedConfig openJGitConfig(org.eclipse.jgit.lib.Config, org.eclipse.jgit.util.FS)'

Attempting to solve https://github.com/kordamp/kordamp-gradle-plugins/issues/267