### PR TITLE
Allow using git worktrees

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     /**
      * Versioning applied to itself
      */
-    id("net.nemerosa.versioning") version "2.14.0"
+    id("net.nemerosa.versioning") version "3.1.0"
     /**
      * Release in GitHub
      */

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Some dependency versions
-jgitVersion = 6.1.0.202203080745-r
+jgitVersion = 7.6.0.202603022253-r
 
 # Placeholders for Bintray credentials
 bintrayUser =

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates jgit to a more recent version.  
It allows supporting git worktrees *(closes #50)*.

It requires bumping to Java 17 *(breaking)*.

> **Note:** the tests do not pass when `commit.gpgsign` git configuration is set to `true` in the environment executing them.
